### PR TITLE
docs: add Contributing → Issue Templates section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ Participants on the Content Strategy track will complete tasks related to the co
 ***Content Strategy: Benefit to Participant***  
 
 Consistent engagement in this track will establish a solid foundation in the content developemnt life cycle and general IT concepts such development environments and User Acceptance Testing (UAT). Participants will occassional have working sessions with content strategists that have 15+ years of experience in the field. These opportunities will help participants become proficient at making strategic decisions backed by research and data for the purpose of increasing content engagement.  
+
+## Contributing
+
+### Issue Templates
+- **🧭 Orientation Mission** — use this template to onboard yourself before submitting code
+- 🐞 **Bug Report** — report problems in the curriculum or scripts
+- ✨ **Enhancement / Feature Request** — propose improvements to code, boot-camp materials, or tooling
+MD


### PR DESCRIPTION
## ✏️ What changed
* Appended a **Contributing** block at the end of `README.md`.
* Added an **Issue Templates** subsection with three bullets:
  - 🧭 **Orientation Mission** – new-joiner onboarding checklist
  - 🐞 **Bug Report**
  - ✨ **Enhancement / Feature Request**

## 🤔 Why it matters
* Makes the repo’s templates discoverable without digging through the `.github` folder.
* Gives newcomers a clear starting point (Orientation Mission) and reduces duplicate questions.
* Aligns with the enhancement template task in Issue #89.

## ✅ Acceptance criteria
- [ ] Section renders correctly in GitHub’s markdown preview.
- [ ] Links to issue templates show up under **New issue → Get started**.

## 🔗 Related
* Closes <!-- or “Part of” if you don’t want auto-close --> #89
