### PR TITLE
docs: add Orientation Mission issue template & README link

### DIFF
--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -1,0 +1,63 @@
+---
+name: "🧭 Orientation Mission"
+about: Kick-off check-list for new JustAskDavidB participants
+title: "[Orientation]: <your-name-here>"
+labels: ["orientation", "good first issue"]
+assignees: ""
+---
+
+# Orientation
+Use this ticket to track **and prove** completion of each orientation task.
+
+## Consultation Calls
+- [ ] Introduction Consultation — schedule & complete
+- [ ] Office Hour — attend & note at least 1 takeaway
+- [ ] Debriefing — decide to stay or exit
+
+## Articles to Read
+- [ ] [JustAskDavidB Explained](https://www.justaskdavidb.com)
+- [ ] [Published Works](https://medium.com/indevelopme-tech-coaching-program)
+
+## Podcast (first 18 eps)
+- [ ] Listen • add **✅** once complete
+- [ ] Post 5 episode comments in this issue
+- [ ] Leave a public review on your chosen platform
+
+## Tools to Install
+- [ ] PyCharm Community
+- [ ] Docker Desktop
+- [ ] GitHub Desktop
+
+## Accounts to Create
+- [ ] GitHub   -  username:
+- [ ] LinkedIn  -  URL:
+- [ ] Slack   -  workspace email:
+- [ ] Medium  -  handle:
+
+## LMS Subscription
+- [ ] Pluralsight *or* ACloudGuru (circle one)
+
+## Mobile Apps (optional, recommended)
+- [ ] GitHub  •  Slack  •  LinkedIn  •  Chosen LMS
+
+## Generative AI Video Sampler — watch & comment
+- [ ] [Asking the Right Question](https://youtu.be/wK7WMfq1Ja0)
+- [ ] [Meet Tommy](https://youtu.be/Z8R1AtJpcWQ)
+- [ ] [AI Trevor Noah explains the Cloud](https://www.youtube.com/watch?v=LbbE8UV0EWo&t=10s)
+- [ ] [Meet Maya](https://youtube.com/shorts/siSr8300N7s)
+
+## Git/GitHub Quest
+- [ ] Review Issue #72 • PR #74 • PR #79
+
+## Markdown Quest
+- [ ] Review Issue #70
+
+## IDE Quest
+- [ ] Review Issue #69 • LinkedIn slide-deck
+
+## Linux Commands Quest
+- [ ] Issue #65 + LinkedIn video
+
+---
+### Completion
+Paste the final checklist with ✅ for every box, then @-mention your mentor.

--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -45,7 +45,7 @@ Check off the platform you used to listen to the podcast:
 ---
 
 ## Accounts to Create
-- [ ] **GitHub** — create at [github.com](https://github.com) ▪ username:  
+- [ ] **GitHub** — create at [github.com](https://github.com) ▪ username:[.            ]  
 - [ ] **LinkedIn** — create at [linkedin.com](https://www.linkedin.com) ▪ profile URL:  
 - [ ] **Slack** — create at [slack.com](https://slack.com) ▪ workspace e-mail:  
 - [ ] **Medium** — create at [medium.com](https://medium.com) ▪ handle:  

--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -9,55 +9,91 @@ assignees: ""
 # Orientation
 Use this ticket to track **and prove** completion of each orientation task.
 
+---
+
 ## Consultation Calls
-- [ ] Introduction Consultation — schedule & complete
-- [ ] Office Hour — attend & note at least 1 takeaway
-- [ ] Debriefing — decide to stay or exit
-
-## Articles to Read
-- [ ] [JustAskDavidB Explained](https://www.justaskdavidb.com)
-- [ ] [Published Works](https://medium.com/indevelopme-tech-coaching-program)
-
-## Podcast (first 18 eps)
-- [ ] Listen • add **✅** once complete
-- [ ] Post 5 episode comments in this issue
-- [ ] Leave a public review on your chosen platform
-
-## Tools to Install
-- [ ] PyCharm Community
-- [ ] Docker Desktop
-- [ ] GitHub Desktop
-
-## Accounts to Create
-- [ ] GitHub   -  username:
-- [ ] LinkedIn  -  URL:
-- [ ] Slack   -  workspace email:
-- [ ] Medium  -  handle:
-
-## LMS Subscription
-- [ ] Pluralsight *or* ACloudGuru (circle one)
-
-## Mobile Apps (optional, recommended)
-- [ ] GitHub  •  Slack  •  LinkedIn  •  Chosen LMS
-
-## Generative AI Video Sampler — watch & comment
-- [ ] [Asking the Right Question](https://youtu.be/wK7WMfq1Ja0)
-- [ ] [Meet Tommy](https://youtu.be/Z8R1AtJpcWQ)
-- [ ] [AI Trevor Noah explains the Cloud](https://www.youtube.com/watch?v=LbbE8UV0EWo&t=10s)
-- [ ] [Meet Maya](https://youtube.com/shorts/siSr8300N7s)
-
-## Git/GitHub Quest
-- [ ] Review Issue #72 • PR #74 • PR #79
-
-## Markdown Quest
-- [ ] Review Issue #70
-
-## IDE Quest
-- [ ] Review Issue #69 • LinkedIn slide-deck
-
-## Linux Commands Quest
-- [ ] Issue #65 + LinkedIn video
+- [ ] **Introduction Consultation** — schedule & complete  
+- [ ] **Office Hour** — attend & note at least 1 takeaway  
+- [ ] **Debriefing** — decide to stay or exit  
 
 ---
+
+## Articles to Read
+- [ ] [JustAskDavidB Explained](https://www.justaskdavidb.com)  
+- [ ] [Published Works](https://medium.com/indevelopme-tech-coaching-program)  
+
+---
+
+## Podcast (first 18 episodes)
+- [ ] Listen • add **✅** once complete  
+- [ ] Post 5 episode comments in this issue  
+- [ ] Leave a public review on your chosen platform  
+
+---
+
+## Tools to Install
+- [ ] **PyCharm** — choose **one** edition:  
+      • [Community](https://www.jetbrains.com/pycharm/download) *(free)* |   
+      • [Professional](https://www.jetbrains.com/pycharm/download) *(30-day trial / free for students & OSS)*  
+- [ ] **Docker Desktop** — [Download](https://www.docker.com/products/docker-desktop/)  
+- [ ] **GitHub Desktop** — [Download](https://desktop.github.com/)  
+
+---
+
+## Accounts to Create
+- [ ] **GitHub** — create at [github.com](https://github.com) ▪ username:  
+- [ ] **LinkedIn** — create at [linkedin.com](https://www.linkedin.com) ▪ profile URL:  
+- [ ] **Slack** — create at [slack.com](https://slack.com) ▪ workspace e-mail:  
+- [ ] **Medium** — create at [medium.com](https://medium.com) ▪ handle:  
+
+---
+
+## LMS Subscription  *(pick one)*
+- [ ] **Pluralsight** — [pluralsight.com](https://www.pluralsight.com)  
+- [ ] **ACloudGuru** — [acloudguru.com](https://www.acloudguru.com)  
+
+---
+
+## Mobile Apps  *(optional but recommended)*
+| App | iOS | Android |
+|-----|-----|---------|
+| GitHub | [App Store](https://apps.apple.com/app/github/id1477376905) | [Play Store](https://play.google.com/store/apps/details?id=com.github.android) |
+| Slack | [App Store](https://apps.apple.com/app/slack/id618783545) | [Play Store](https://play.google.com/store/apps/details?id=com.Slack) |
+| LinkedIn | [App Store](https://apps.apple.com/app/linkedin-network-job-finder/id288429040) | [Play Store](https://play.google.com/store/apps/details?id=com.linkedin.android) |
+| Pluralsight | [App Store](https://apps.apple.com/app/pluralsight-skills/id829116099) | [Play Store](https://play.google.com/store/apps/details?id=com.pluralsight) |
+| ACloudGuru | [App Store](https://apps.apple.com/app/acloud-guru/id1048007070) | [Play Store](https://play.google.com/store/apps/details?id=com.acloudguru) |
+
+_Check off a row once you’ve installed on **either** platform._
+
+---
+
+## Generative AI Video Sampler — watch & comment
+- [ ] [Asking the Right Question](https://youtu.be/wK7WMfq1Ja0)  
+- [ ] [Meet Tommy](https://youtu.be/Z8R1AtJpcWQ)  
+- [ ] [AI Trevor Noah explains the Cloud](https://www.youtube.com/watch?v=LbbE8UV0EWo&t=10s)  
+- [ ] [Meet Maya](https://youtube.com/shorts/siSr8300N7s)  
+
+---
+
+## Git/GitHub Quest
+- [ ] Review Issue #72 • PR #74 • PR #79  
+
+---
+
+## Markdown Quest
+- [ ] Review Issue #70  
+
+---
+
+## IDE Quest
+- [ ] Review Issue #69 • LinkedIn slide-deck  
+
+---
+
+## Linux Commands Quest
+- [ ] Issue #65 + LinkedIn video  
+
+---
+
 ### Completion
-Paste the final checklist with ✅ for every box, then @-mention your mentor.
+Paste the final checklist with **✅** for every box, then **@-mention your mentor**.

--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -1,7 +1,7 @@
 ---
 name: "🧭 Orientation Mission"
 about: Kick-off check-list for new JustAskDavidB participants
-title: "[Orientation]: <your-name-here>"
+title: "[Orientation]: {Your FirstName First Letter of LastName} (ie: David B.)"
 labels: ["orientation", "good first issue"]
 assignees: ""
 ---
@@ -54,7 +54,8 @@ Check off the platform you used to listen to the podcast:
 
 ## LMS Subscription  *(pick one)*
 - [ ] **Pluralsight** — [pluralsight.com](https://www.pluralsight.com)  
-- [ ] **ACloudGuru** — [acloudguru.com](https://www.acloudguru.com)  
+- [ ] **ACloudGuru** — [acloudguru.com](https://www.acloudguru.com) 
+- [ ] **AWS Skillbuilder** - [skillbuilder.aws.com](https://explore.skillbuilder.aws/learn) 
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -24,11 +24,15 @@ Use this ticket to track **and prove** completion of each orientation task.
 
 ---
 
-## Podcast (first 18 episodes)
-- [ ] Listen • add **✅** once complete  
-- [ ] Post 5 episode comments in this issue  
-- [ ] Leave a public review on your chosen platform  
+### ***Platform Used for Podcast***
+Check off the platform you used to listen to the podcast:
+- [ ] [Spotify](https://open.spotify.com/show/7altHV6BJYSMS4TlbsbdZy?si=3c24a79eb22540c1)
+- [ ] [Apple Podcast](https://podcasts.apple.com/us/podcast/justaskdavidb/id1681610153)
+- [ ] [ListenNotes](https://www.listennotes.com/podcasts/justaskdavidb-developme10x-8G4BIveuw7R/)
 
+### ***Feedback About Podcast Episodes***
+- [ ] Provided a comment in this issue ticket about the five (5) of the most relevant episodes
+- [ ] Provided a review on the podcast platform to help others
 ---
 
 ## Tools to Install
@@ -75,25 +79,23 @@ _Check off a row once you’ve installed on **either** platform._
 
 ---
 
-## Git/GitHub Quest
-- [ ] Review Issue #72 • PR #74 • PR #79  
+### ***Issue Template Quest***
+- [ ] [Reviewed Issue Ticket](https://github.com/inDevelopme/justaskdavidb/issues/72)
+- [ ] [Reviewed Pull Request-1](https://github.com/inDevelopme/justaskdavidb/pull/74)
+- [ ] [Reviewed Pull Request-2](https://github.com/inDevelopme/justaskdavidb/pull/79)
 
----
+### ***Markdown Documentation Quest***
+- [ ] [Reviewed Issue Ticket](https://github.com/inDevelopme/justaskdavidb/issues/70)
 
-## Markdown Quest
-- [ ] Review Issue #70  
+### ***What is an IDE***
+- [ ] [Review Issue Ticket](https://github.com/inDevelopme/justaskdavidb/issues/69)
+- [ ] [Review PowerPoint Presentation](https://www.linkedin.com/posts/developme10x_what-is-an-ide-activity-7186725214083248128-RFvW)
 
----
+### ***Linux Command Quest***
+- [ ] [Reviewed Issue Ticket](https://github.com/inDevelopme/justaskdavidb/issues/65)
+- [ ] [Watched LinkedIn Video](https://www.linkedin.com/posts/indevelopme_indevelopme-justaskdavidb-developme10x-activity-7232098696102862849-Q3V3)
 
-## IDE Quest
-- [ ] Review Issue #69 • LinkedIn slide-deck  
+### ***Git Quest***
+- [ ] [Review: Mac Users need to know how to install git](https://github.com/inDevelopme/justaskdavidb/issues/68)
 
----
-
-## Linux Commands Quest
-- [ ] Issue #65 + LinkedIn video  
-
----
-
-### Completion
-Paste the final checklist with **✅** for every box, then **@-mention your mentor**.
+Estimated Time: 13 - 21 hours

--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -45,7 +45,7 @@ Check off the platform you used to listen to the podcast:
 ---
 
 ## Accounts to Create
-- [ ] **GitHub** — create at [github.com](https://github.com) ▪ username:[.            ]  
+- [ ] **GitHub** — create at [github.com](https://github.com) ▪ username: 
 - [ ] **LinkedIn** — create at [linkedin.com](https://www.linkedin.com) ▪ profile URL:  
 - [ ] **Slack** — create at [slack.com](https://slack.com) ▪ workspace e-mail:  
 - [ ] **Medium** — create at [medium.com](https://medium.com) ▪ handle:  


### PR DESCRIPTION
## ✏️ What changed
* **Added** `.github/ISSUE_TEMPLATE/orientation_mission.md`  
  * Provides a step-by-step onboarding checklist for new participants.
* **Updated** `README.md`  
  * Added a Contributing → Issue Templates section that links to the new **🧭 Orientation Mission** template.

## 🤔 Why it matters
* Makes the onboarding process self-service—no more hunting for tasks in Slack threads or docs.
* Gives maintainers a single place to verify a contributor has completed orientation before merging their future PRs.

## ✅ Acceptance criteria
- [x] Orientation Mission template renders in the *New issue* menu.
- [x] README renders the new bullet correctly (no broken Markdown).

## 🔗 Related
Closes <!-- or "Part of" if you prefer not to auto-close --> #89
