### PR TITLE
Chore/content overtime cron

### DIFF
--- a/.github/ISSUE_TEMPLATE/orientation_mission.md
+++ b/.github/ISSUE_TEMPLATE/orientation_mission.md
@@ -1,0 +1,63 @@
+---
+name: "🧭 Orientation Mission"
+about: Kick-off check-list for new JustAskDavidB participants
+title: "[Orientation]: <your-name-here>"
+labels: ["orientation", "good first issue"]
+assignees: ""
+---
+
+# Orientation
+Use this ticket to track **and prove** completion of each orientation task.
+
+## Consultation Calls
+- [ ] Introduction Consultation — schedule & complete
+- [ ] Office Hour — attend & note at least 1 takeaway
+- [ ] Debriefing — decide to stay or exit
+
+## Articles to Read
+- [ ] [JustAskDavidB Explained](https://www.justaskdavidb.com)
+- [ ] [Published Works](https://medium.com/indevelopme-tech-coaching-program)
+
+## Podcast (first 18 eps)
+- [ ] Listen • add **✅** once complete
+- [ ] Post 5 episode comments in this issue
+- [ ] Leave a public review on your chosen platform
+
+## Tools to Install
+- [ ] PyCharm Community
+- [ ] Docker Desktop
+- [ ] GitHub Desktop
+
+## Accounts to Create
+- [ ] GitHub   -  username:
+- [ ] LinkedIn  -  URL:
+- [ ] Slack   -  workspace email:
+- [ ] Medium  -  handle:
+
+## LMS Subscription
+- [ ] Pluralsight *or* ACloudGuru (circle one)
+
+## Mobile Apps (optional, recommended)
+- [ ] GitHub  •  Slack  •  LinkedIn  •  Chosen LMS
+
+## Generative AI Video Sampler — watch & comment
+- [ ] [Asking the Right Question](https://youtu.be/wK7WMfq1Ja0)
+- [ ] [Meet Tommy](https://youtu.be/Z8R1AtJpcWQ)
+- [ ] [AI Trevor Noah explains the Cloud](https://www.youtube.com/watch?v=LbbE8UV0EWo&t=10s)
+- [ ] [Meet Maya](https://youtube.com/shorts/siSr8300N7s)
+
+## Git/GitHub Quest
+- [ ] Review Issue #72 • PR #74 • PR #79
+
+## Markdown Quest
+- [ ] Review Issue #70
+
+## IDE Quest
+- [ ] Review Issue #69 • LinkedIn slide-deck
+
+## Linux Commands Quest
+- [ ] Issue #65 + LinkedIn video
+
+---
+### Completion
+Paste the final checklist with ✅ for every box, then @-mention your mentor.

--- a/.github/content-reminder.md
+++ b/.github/content-reminder.md
@@ -1,0 +1,5 @@
+## 📢 What to share this week
+- An article you read
+- A code snippet you wrote
+- A short Loom or YouTube link explaining a concept
+_Please comment your contribution below and close the issue when done._

--- a/.github/workflows/share_content_overtime.yml
+++ b/.github/workflows/share_content_overtime.yml
@@ -1,0 +1,17 @@
+name: Share Content Overtime
+
+on:
+  schedule:
+    # every Monday at 15:00 UTC (10 am CDT)
+    - cron:  '0 15 * * 1'
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create reminder issue
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Weekly content drop – $(date '+%Y-m-d')"
+          content-filepath: .github/content-reminder.md
+          labels: share-content

--- a/docs/missions/boolean_algebra_mission.md
+++ b/docs/missions/boolean_algebra_mission.md
@@ -1,0 +1,38 @@
+# Boolean Algebra Mission  
+*Author: Tredarion Hampton • Last updated: 2025-06-14*
+
+## 1  Why this matters
+Boolean algebra underpins digital circuits, complex `if` statements, and search filters.
+
+## 2  Learning goals
+1. Build truth tables (AND, OR, NOT, XOR)  
+2. Apply De Morgan's Laws to simplify expressions  
+3. Minimize a 3-variable function with a Karnaugh Map  
+
+## 3  Prerequisites
+- Binary arithmetic basics  
+- Familiarity with programming conditionals  
+
+## 4  Content outline
+| #  | Section        | Topics               | Est. mins |
+|----|----------------|----------------------|-----------|
+| 4.1| Truth Tables   | AND, OR, NOT         | 20        |
+| 4.2| De Morgan's    | ¬(A·B)=¬A+¬B, etc.   | 15        |
+| 4.3| Logic Gates    | symbols, timing      | 15        |
+| 4.4| Karnaugh Maps  | 2-, 3-, 4-var maps   | 30        |
+
+## 5  Exercises
+| # | Task                                  | Deliverable |
+|---|---------------------------------------|-------------|
+| 1 | Truth table for `F = A·B + ¬C`        | screenshot  |
+| 2 | Simplify `¬(A+B)·(C+¬D)`              | written     |
+| 3 | 3-var K-map minimization              | photo/scan  |
+
+## 6  Resources
+- [Logic-gate simulator](https://academo.org/demos/logic-gate-simulator/)  
+- [Boolean Basics (AllAboutCircuits)](https://www.allaboutcircuits.com/textbook/digital/chpt-7/boolean-algebra/)  
+- [K-maps in 12 min](https://youtu.be/OCj9bSR2d_A)  
+
+## 7  Submission
+Fork → `submissions/<handle>/boolean-algebra/` → add deliverables  
+→ PR titled `feat: <handle> completes Boolean Algebra Mission`.

--- a/docs/missions/hyperv_windows_resolution_mission.md
+++ b/docs/missions/hyperv_windows_resolution_mission.md
@@ -1,0 +1,40 @@
+# Resolving Hyper-V for Windows Mission  
+*Author: Tredarion Hampton • Last updated: 2025-06-14*
+
+## Objective
+Enable Hyper-V on Windows 10/11, resolve common conflicts, and verify Docker Desktop.
+
+## Learning goals
+- Turn on Hyper-V & WSL 2 features  
+- Enable CPU virtualization in BIOS/UEFI  
+- Diagnose memory-reservation and VM conflicts  
+
+## Task list
+1. **Pre-check**  
+   ```powershell
+   systeminfo | find "Hyper"
+   ```
+
+2. **Enable features** (PowerShell Admin)
+   ```powershell
+   dism /online /enable-feature /featurename:Microsoft-Hyper-V-All /all /norestart
+   ```
+
+3. **BIOS/UEFI** — enable Intel VT-x / AMD-V (photo proof)
+
+4. **Post-check** — run `systeminfo` again
+
+5. **Docker smoke-test** — `docker run hello-world` (screenshot)
+
+## Troubleshooting
+
+| Symptom                 | Cause          | Fix                                     |
+|-------------------------|----------------|----------------------------------------|
+| Hyper-V not available   | VT-x/AMD-V off | Enable in BIOS                          |
+| Docker exit code 12     | Low memory     | Reduce VM RAM                           |
+| VMware/VirtualBox fails | Hyper-V active | `bcdedit /set hypervisorlaunchtype off` |
+
+## Resources
+- [Enable Hyper-V (Microsoft)](https://learn.microsoft.com/windows-server/virtualization/hyper-v/get-started/enable-hyper-v)
+
+> **Deliverable:** BEFORE & AFTER screenshots + 100-word summary.


### PR DESCRIPTION
## 🔄 What changed
* Added `.github/workflows/share_content_overtime.yml`
  * Runs every **Monday @ 15 UTC** (10 AM CDT).
  * Creates a new issue titled **“Weekly content drop – <date>”** using `peter-evans/create-issue-from-file`.
* Added `.github/content-reminder.md`
  * Starter checklist that prompts contributors to share an article, code snippet, or short video each week.

## 🤔 Why it matters
* Keeps fresh content flowing into the repo without manual nudges.
* Encourages a culture of regular knowledge-sharing and reduces “silent weeks.”
* Aligns with the **Share Content Overtime** goal in the 2025 Q3 mission bundle.

## ✅ Acceptance criteria
- [ ] Workflow appears under **Actions** after merge.
- [ ] A new “Weekly content drop” issue is autogenerated on the next Monday.
- [ ] The issue body renders without broken Markdown.

## 🗂️ Related work
Part of the broader **Mission Bundle — 2025-Q3** tracking issue (to be opened).

